### PR TITLE
Adding old version for upgrade testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-ENV ISTIO_VERSION 1.6.8
+ENV ISTIO_VERSION 1.6.7
 
 RUN apk update && apk add curl bash coreutils
 


### PR DESCRIPTION
need istio 1.6.7 with latest installer changes for upgrade testing to be made available