### PR TITLE
Add Grafana dashboards to rancher-monitoring if installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 
 ENV ISTIO_VERSION 1.7.3
 
-RUN apk update && apk add curl bash coreutils
+RUN apk update && apk add curl bash coreutils jq
 
 # Get Istio Charts
 
@@ -17,5 +17,6 @@ RUN mv ./kubectl /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 
 # Add scripts for Istio
 COPY scripts /usr/local/app/scripts/
-RUN chmod +x /usr/local/app/scripts/init_kubeconfig.sh /usr/local/app/scripts/run.sh /usr/local/app/scripts/create_istio_system.sh /usr/local/app/scripts/uninstall_istio_system.sh
+RUN chmod +x /usr/local/app/scripts/init_kubeconfig.sh /usr/local/app/scripts/run.sh /usr/local/app/scripts/create_istio_system.sh /usr/local/app/scripts/uninstall_istio_system.sh /usr/local/app/scripts/get_grafana_dashboards.sh
+RUN mkdir -p /usr/local/app/dashboards && /usr/local/app/scripts/get_grafana_dashboards.sh
 ENTRYPOINT [ "/usr/local/app/scripts/run.sh" ]

--- a/scripts/create_istio_system.sh
+++ b/scripts/create_istio_system.sh
@@ -31,3 +31,18 @@ else
   echo "running istioctl upgrade"
   istioctl upgrade -i $ISTIO_NAMESPACE -y ${ISTIO_FILES[@]/#/-f }
 fi
+
+if kubectl get namespace cattle-dashboards; then
+  # delete existing managed istio dashboards
+  kubectl delete configmap -n cattle-dashboards -l istio_dashboard=1
+  for dashboard in /usr/local/app/dashboards/*.json; do
+    name="istio-dashboard-$(basename ${dashboard} ".json")"
+    # replace datasource input placeholder in dashboard with datasource name in rancher-monitoring
+    sed -i 's/${DS_PROMETHEUS}/Prometheus/g' ${dashboard}
+    # if a configmap with the name already exists and is not managed by this installer script, skip it and do not add the istio_dashboard label
+    if kubectl create configmap ${name} -n cattle-dashboards --from-file=$(basename ${dashboard})=${dashboard}; then
+      kubectl label configmap ${name} -n cattle-dashboards grafana_dashboard=1
+      kubectl label configmap ${name} -n cattle-dashboards istio_dashboard=1
+    fi
+  done
+fi

--- a/scripts/get_grafana_dashboards.sh
+++ b/scripts/get_grafana_dashboards.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# https://istio.io/latest/docs/ops/integrations/grafana/#option-1-quick-start
+for DASHBOARD in 7639 11829 7636 7630 7642 7645; do
+  REVISION="$(curl -s https://grafana.com/api/dashboards/${DASHBOARD}/revisions -s | jq ".items[] | select(.description | contains(\"${ISTIO_VERSION}\")) | .revision")"
+  curl -s https://grafana.com/api/dashboards/${DASHBOARD}/revisions/${REVISION}/download > /usr/local/app/dashboards/${DASHBOARD}.json
+done

--- a/scripts/uninstall_istio_system.sh
+++ b/scripts/uninstall_istio_system.sh
@@ -10,3 +10,7 @@ fi
 
 echo "uninstalling istio"
 istioctl manifest generate -i $ISTIO_NAMESPACE ${ISTIO_FILES[@]/#/-f } | kubectl delete --ignore-not-found=true -f -
+
+if kubectl get namespace cattle-dashboards; then
+  kubectl delete configmap -n cattle-dashboards -l istio_dashboard=1
+fi


### PR DESCRIPTION
This adds the istio Grafana dashboards for the correct istio version to the correct rancher-monitoring dashboards namespace, if rancher-monitoring is installed.
Dashboards are downloaded at build time so that the installation is not relying on grafana.com to be available or reachable (e.g. in air-gapped installations).

For easy testing I built and pushed an image to bashofmann/istio-installer:1.7.1-1 (https://hub.docker.com/repository/docker/bashofmann/istio-installer).