### PR TITLE
Support istio installation in airgapped environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@ RUN apk update && apk add curl bash coreutils jq
 
 # Get Istio Charts
 
-
-# Get Istio
-RUN curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VERSION} sh -
-RUN mv istio-${ISTIO_VERSION}/bin/istioctl /usr/bin && chmod +x /usr/bin/istioctl
+# Get istioctl and Istio manifests
+RUN curl -LO https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-linux-amd64.tar.gz \
+    && tar -xvf istio-${ISTIO_VERSION}-linux-amd64.tar.gz \
+    && mv istio-${ISTIO_VERSION}/bin/istioctl /usr/bin && chmod +x /usr/bin/istioctl \
+    && mkdir -p /usr/local/app && mv istio-${ISTIO_VERSION}/manifests /usr/local/app \
+    && rm -rf istio-${ISTIO_VERSION} && rm istio-${ISTIO_VERSION}-linux-amd64.tar.gz
 
 # Get kubectl
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl

--- a/scripts/create_istio_system.sh
+++ b/scripts/create_istio_system.sh
@@ -25,11 +25,11 @@ fi
 versions=$(kubectl get --ignore-not-found=true deploy istiod -n $ISTIO_NAMESPACE -o=jsonpath='{$.spec.template.spec.containers[*].image}')
 if [[ $versions == "" ]]; then
   echo "running istioctl install"
-  istioctl install -i $ISTIO_NAMESPACE -y ${ISTIO_FILES[@]/#/-f }
+  istioctl install --manifests /usr/local/app/manifests -i $ISTIO_NAMESPACE -y ${ISTIO_FILES[@]/#/-f }
 
 else
   echo "running istioctl upgrade"
-  istioctl upgrade -i $ISTIO_NAMESPACE -y ${ISTIO_FILES[@]/#/-f }
+  istioctl upgrade --manifests /usr/local/app/manifests -i $ISTIO_NAMESPACE -y ${ISTIO_FILES[@]/#/-f }
 fi
 
 if kubectl get namespace cattle-dashboards; then

--- a/scripts/uninstall_istio_system.sh
+++ b/scripts/uninstall_istio_system.sh
@@ -9,7 +9,7 @@ if test -f "/app/overlay-config.yaml"; then
 fi
 
 echo "uninstalling istio"
-istioctl manifest generate -i $ISTIO_NAMESPACE ${ISTIO_FILES[@]/#/-f } | kubectl delete --ignore-not-found=true -f -
+istioctl manifest generate --manifests /usr/local/app/manifests -i $ISTIO_NAMESPACE ${ISTIO_FILES[@]/#/-f } | kubectl delete --ignore-not-found=true -f -
 
 if kubectl get namespace cattle-dashboards; then
   kubectl delete configmap -n cattle-dashboards -l istio_dashboard=1


### PR DESCRIPTION
By default istioctl loads the istio manifests from github. In airgapped environments this request fails. istioctl also allows to reference the manifests on a local path.

This bundles the istio manifests into the docker image and uses the local manifests during installation, upgrade and uninstall.

Addresses: https://github.com/rancher/rancher/issues/30743