### PR TITLE
Add support for istio 1.9.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-ENV ISTIO_VERSION 1.10.4
+ENV ISTIO_VERSION 1.9.8
 
 RUN apk update && apk add curl bash coreutils jq
 


### PR DESCRIPTION
Add istio 1.9.8 to the installer 

There are no changes needed for the installer scriptss to work for 1.9.x and 1.10.x which is why we only see a version change. 