### PR TITLE
Add nginx user to dashboard directory permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY nginx.conf /etc/nginx/nginx.conf
 RUN mkdir -p /opt/istio-releases && /usr/local/app/scripts/fetch_istio_releases.sh /opt/istio-releases
 RUN mkdir -p /var/cache/nginx
 
-RUN chown -R nginx:nginx /var/cache/nginx /etc/ssl /var/run /usr/share/nginx /usr/local/share/ca-certificates
+RUN chown -R nginx:nginx /var/cache/nginx /etc/ssl /var/run /usr/share/nginx /usr/local/share/ca-certificates /usr/local/app/dashboards
 
 RUN echo "nginx ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/nginx \
         && chmod 0440 /etc/sudoers.d/nginx

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -12,7 +12,7 @@ if $RELEASE_MIRROR_ENABLED; then
     sudo nginx -c /etc/nginx/nginx.conf
 fi
 
-if $DEBUG; then
+if [[ $SECONDS_SLEEP > 0 ]]; then
     echo "starting sleep for ${SECONDS_SLEEP} seconds"
     sleep ${SECONDS_SLEEP}s
 fi


### PR DESCRIPTION
### Issue
https://github.com/rancher/rancher/issues/30842

### Problem
When running the `istio-installer` image to install and upgrade in rancher-istio chart, I am seeing the following errors: 
```
Installation completesed: can't create temp file '/usr/local/app/dashboards/11829.jsonXXXXXX': Permission denied
--
Thu, Sep 30 2021 11:58:47 am | configmap/istio-dashboard-11829 created
Thu, Sep 30 2021 11:58:47 am | configmap/istio-dashboard-11829 labeled
Thu, Sep 30 2021 11:58:47 am | configmap/istio-dashboard-11829 labeled
Thu, Sep 30 2021 11:58:47 am | sed: can't create temp file '/usr/local/app/dashboards/7630.jsonXXXXXX': Permission denied
Thu, Sep 30 2021 11:58:47 am | configmap/istio-dashboard-7630 created
Thu, Sep 30 2021 11:58:48 am | configmap/istio-dashboard-7630 labeled
Thu, Sep 30 2021 11:58:48 am | configmap/istio-dashboard-7630 labeled
Thu, Sep 30 2021 11:58:48 am | sed: can't create temp file '/usr/local/app/dashboards/7636.jsonXXXXXX': Permission denied
Thu, Sep 30 2021 11:58:48 am | configmap/istio-dashboard-7636 created
Thu, Sep 30 2021 11:58:48 am | configmap/istio-dashboard-7636 labeled
Thu, Sep 30 2021 11:58:49 am | configmap/istio-dashboard-7636 labeled
Thu, Sep 30 2021 11:58:49 am | sed: can't create temp file '/usr/local/app/dashboards/7639.jsonXXXXXX': Permission denied
Thu, Sep 30 2021 11:58:49 am | configmap/istio-dashboard-7639 created
Thu, Sep 30 2021 11:58:49 am | configmap/istio-dashboard-7639 labeled
Thu, Sep 30 2021 11:58:49 am | configmap/istio-dashboard-7639 labeled
Thu, Sep 30 2021 11:58:49 am | sed: can't create temp file '/usr/local/app/dashboards/7642.jsonXXXXXX': Permission denied
Thu, Sep 30 2021 11:58:49 am | configmap/istio-dashboard-7642 created
Thu, Sep 30 2021 11:58:50 am | configmap/istio-dashboard-7642 labeled
Thu, Sep 30 2021 11:58:50 am | configmap/istio-dashboard-7642 labeled
Thu, Sep 30 2021 11:58:50 am | sed: can't create temp file '/usr/local/app/dashboards/7645.jsonXXXXXX': Permission denied
Thu, Sep 30 2021 11:58:50 am | configmap/istio-dashboard-7645 created
Thu, Sep 30 2021 11:58:50 am | configmap/istio-dashboard-7645 labeled
Thu, Sep 30 2021 11:58:50 am | configmap/istio-dashboard-7645 labeled
```
This is due to the permission changes that have occurred in the istio-installer. This is the specific line that is failing https://github.com/rancher/istio-installer/blob/541626ae8096eb29859e900057cf4823ec0985d0/scripts/create_istio_system.sh#L47

## Solution
Add the `/usr/local/app/dashboards` dir path to the chown command in the Dockerfile.
When running the `istio-installer` image that has the chown change in it to install and upgrade in rancher-istio chart, I am seeing the following: 
```
configmap "istio-dashboard-11829" deleted
--
Thu, Sep 30 2021 12:02:29 pm | configmap "istio-dashboard-7630" deleted
Thu, Sep 30 2021 12:02:29 pm | configmap "istio-dashboard-7636" deleted
Thu, Sep 30 2021 12:02:29 pm | configmap "istio-dashboard-7639" deleted
Thu, Sep 30 2021 12:02:29 pm | configmap "istio-dashboard-7642" deleted
Thu, Sep 30 2021 12:02:29 pm | configmap "istio-dashboard-7645" deleted
Thu, Sep 30 2021 12:02:29 pm | configmap/istio-dashboard-11829 created
Thu, Sep 30 2021 12:02:29 pm | configmap/istio-dashboard-11829 labeled
Thu, Sep 30 2021 12:02:29 pm | configmap/istio-dashboard-11829 labeled
Thu, Sep 30 2021 12:02:29 pm | configmap/istio-dashboard-7630 created
Thu, Sep 30 2021 12:02:30 pm | configmap/istio-dashboard-7630 labeled
Thu, Sep 30 2021 12:02:30 pm | configmap/istio-dashboard-7630 labeled
Thu, Sep 30 2021 12:02:30 pm | configmap/istio-dashboard-7636 created
Thu, Sep 30 2021 12:02:30 pm | configmap/istio-dashboard-7636 labeled
Thu, Sep 30 2021 12:02:31 pm | configmap/istio-dashboard-7636 labeled
Thu, Sep 30 2021 12:02:31 pm | configmap/istio-dashboard-7639 created
Thu, Sep 30 2021 12:02:31 pm | configmap/istio-dashboard-7639 labeled
Thu, Sep 30 2021 12:02:31 pm | configmap/istio-dashboard-7639 labeled
Thu, Sep 30 2021 12:02:31 pm | configmap/istio-dashboard-7642 created
Thu, Sep 30 2021 12:02:31 pm | configmap/istio-dashboard-7642 labeled
Thu, Sep 30 2021 12:02:32 pm | configmap/istio-dashboard-7642 labeled
Thu, Sep 30 2021 12:02:32 pm | configmap/istio-dashboard-7645 created
Thu, Sep 30 2021 12:02:32 pm | configmap/istio-dashboard-7645 labeled
Thu, Sep 30 2021 12:02:32 pm | configmap/istio-dashboard-7645 labeled
Thu, Sep 30 2021 12:02:32 pm | ✔ Installation complete
```