### PR TITLE
Backport k8s server IP to Istio 1.10.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-ENV ISTIO_VERSION 1.11.4
+ENV ISTIO_VERSION 1.10.4
 RUN apk update && apk add curl bash coreutils jq ca-certificates openssl nginx sudo
 
 # Get Istio

--- a/scripts/fetch_istio_releases.sh
+++ b/scripts/fetch_istio_releases.sh
@@ -6,7 +6,7 @@ RELEASE_DIR=${1}
 echo ${RELEASE_DIR}
 
 # Istio versions that need to be supported in the image for airgap installation.
-istio_version_array=(1.7.1 1.7.3 1.8.3 1.8.5 1.8.6 1.9.3 1.9.5 1.9.6 1.9.8 1.10.4 1.11.4)
+istio_version_array=(1.7.1 1.7.3 1.8.3 1.8.5 1.8.6 1.9.3 1.9.5 1.9.6 1.9.8 1.10.4)
 
 if [ -z "${RELEASE_DIR}" ]; then
   echo "No directory given"
@@ -18,7 +18,7 @@ if [ -d "${RELEASE_DIR}" ] ; then
 
   for v in "${istio_version_array[@]}"; do
     curl -sOL https://github.com/istio/istio/releases/download/$v/istio-$v-linux-amd64.tar.gz
-  done 
+  done
 
   for f in *.tar.gz; do
     if [ -f "$f" ]; then


### PR DESCRIPTION
### Issue(s)
https://github.com/rancher/rancher/issues/35341
https://github.com/rancher/rancher/issues/33824


### Description
Change istio version from 1.11.4 to 1.10.4 so I can create a tag to backport the server IP fix with Istio 1.10.4 