### PR TITLE
Add manual testing steps for docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The current implementation of the `istioctl upgrade` command makes a call to ext
 ## Build
 The istio-installer image is built using drone when a new tag is created and pushed to repository. See drone.yaml for drone configurations.
 
-When building the image locally, run `docker build -t <your_docker_hub_repo>/istio-installer:<tag> .`
+When building and tagging the image locally, run `docker build -t <your_docker_hub_repo>/istio-installer:<tag> .`
 
 ####  How to tag
 The istio installer uses the following version format for tags: `<x.x.x>-rancher<x>`
@@ -50,3 +50,95 @@ If you need to re-tag the same version, that may look like this:
 git tag 1.9.6-rancher2
 git push upstream 1.9.6-rancher2
 ```
+
+## Manual Tests
+
+### Test the Standlone Docker Image
+The first test is to run the docker image on its own (i.e not using the rancher-istio chart to run the image). This will allow you to more quickly find issues relating to the docker image configuration.
+
+1. Build the docker image by running `docker build -t <your_docker_hub_repo>/istio-installer:<tag> .`
+
+2. Run docker image by running `docker run <your_docker_hub_repo>/istio-installer:<tag>`.
+
+Check the output for errors and fix them as found.
+
+### Test Docker Image Works in Rancher-Istio chart
+The second test is to check the docker image in the [rancher-istio chart](https://github.com/rancher/charts "rancher-istio chart"). This will help you identify any permission issues or additional configuration problems that were not identified in the standalone docker image test.
+
+1. Build the docker image by running `docker build -t <your_docker_hub_repo>/istio-installer:<tag> .` Note: if you already built the image in the previous test, you do not need to build it again.
+2. Push your image to docker hub by running `docker push <your_docker_hub_repo>/istio-installer:<tag>`.
+3. Setup a rancher instance (can be single node or HA).
+4. Create a large downstream cluster with default settings
+5. In your downstream cluster, navigate to Apps & Market >> Charts.
+6. Select rancher-istio, and install the latest version of istio (or version of istio that you are creating a bug fix for).
+7. Select `system` project, edit options by disabling kiali (Note: only do this if you have not installed rancher-monitoring), then select eidt yaml and make the following updates to the yaml:
+
+* update the `installer.repository`: to `repository: <your_docker_hub_repo>/istio-installer`,
+* update the `installer.tag`: to tag: `<tag>`
+* update the `installer.debug.secondsSleep`: to `secondsSleep: 30`
+> Here is an example of those changes. This is not the entire values.yaml, it is just a small portion of it:
+```
+...
+installer:
+  debug:
+    secondsSleep: 30
+  releaseMirror:
+    enabled: false
+  repository: testuser/istio-installer
+  tag: v1.0.0
+...
+```
+8. Click install
+9. Navigate to Workload >> Pods >> find the istio-installer pod and view logs to find an issues.
+10. If no issues are found while checking the logs, see that the helm-operation results in a succesfull install and continue
+11. Navigate to Apps & Marketplace >> Charts, select rancher-istio, click Update, leave default options, click Next, click Update
+13. Navigate to Workload >> Pods >> find the istio-installer pod and view logs to see if there are any issues.
+14. If there are issues, then Update usually fails.
+
+
+### Test Image Mirror works in Rancher-Istio chart
+The second test is to check the docker image in the [rancher-istio chart](https://github.com/rancher/charts "rancher-istio chart"). This will help you identify any permission issues or additional configuration problems that were not identified in the standalone docker image test.
+
+1. Build the docker image by running `docker build -t <your_docker_hub_repo>/istio-installer:<tag> .` Note: if you already built the image in the previous test, you do not need to build it again.
+2. Push your image to docker hub by running `docker push <your_docker_hub_repo>/istio-installer:<tag>`.
+3. Setup a rancher instance (can be single node or HA).
+4. Create a large downstream cluster with default settings
+5. In your downstream cluster, navigate to Apps & Market >> Charts.
+6. Select rancher-istio, and install the latest version of istio (or version of istio that you are creating a bug fix for).
+7. Select `system` project, edit options by disabling kiali (Note: only do this if you have not installed rancher-monitoring), then select eidt yaml and make the following updates to the yaml:
+
+* update the `installer.repository`: to `repository: <your_docker_hub_repo>/istio-installer`,
+* update the `installer.tag`: to tag: `<tag>`
+* update the `installer.debug.secondsSleep`: to `secondsSleep: 30`
+> Here is an example of those changes. This is not the entire values.yaml, it is just a small portion of it:
+```
+...
+installer:
+  debug:
+    secondsSleep: 30
+  releaseMirror:
+    enabled: false
+  repository: testuser/istio-installer
+  tag: v1.0.0
+...
+```
+8. Click install
+9. Navigate to Workload >> Pods >> find the istio-installer pod and view logs to find an issues.
+10. If no issues are found while checking the logs, see that the helm-operation results in a succesfull install and continue
+11. Navigate to Apps & Marketplace >> Charts, select rancher-istio, click Update, ensure the version in the dropdown is that same as selected on install, click next, and edit yaml to make the following updates:
+* update the `installer.releaseMirror.enabled` to `enabled: true`.
+> Here is an example of those changes. This is not the entire values.yaml, it is just a small portion of it:
+```
+...
+installer:
+  debug:
+    secondsSleep: 30
+  releaseMirror:
+    enabled: true
+  repository: testuser/istio-installer
+  tag: v1.0.0
+...
+```
+12. Click Update
+13. Navigate to Workload >> Pods >> find the istio-installer pod and view logs to see if there are any issues.
+14. If there are issues, then Update usually fails.


### PR DESCRIPTION
Added steps that can be followed to test the docker image prior to creating a pull request in rancher/istio-installer or rancher/charts for rancher-istio changes. 