### PR TITLE
Backport SLE BCI base image changes to Istio 1.10.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.suse.com/suse/sle15:15.3
-ENV ISTIO_VERSION 1.11.4
+ENV ISTIO_VERSION 1.10.4
 RUN zypper -n update && \
     zypper -n install curl jq openssl nginx tar gzip sudo
 

--- a/scripts/fetch_istio_releases.sh
+++ b/scripts/fetch_istio_releases.sh
@@ -6,7 +6,7 @@ RELEASE_DIR=${1}
 echo ${RELEASE_DIR}
 
 # Istio versions that need to be supported in the image for airgap installation.
-istio_version_array=(1.7.1 1.7.3 1.8.3 1.8.5 1.8.6 1.9.3 1.9.5 1.9.6 1.9.8 1.10.4)
+istio_version_array=(1.7.1 1.7.3 1.8.3 1.8.5 1.8.6 1.9.3 1.9.5 1.9.6 1.9.8 1.10.4 1.11.4)
 
 if [ -z "${RELEASE_DIR}" ]; then
   echo "No directory given"


### PR DESCRIPTION
This PR backport SLE BCI changes to Istio 1.10.4. 
Related: https://github.com/rancher/rancher/issues/35704