### PR TITLE
[release/1.12] Add support for istio 1.12.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.suse.com/suse/sle15:15.3
-ENV ISTIO_VERSION 1.11.7
+ENV ISTIO_VERSION 1.12.6
 RUN zypper -n update && \
     zypper -n install curl jq openssl nginx tar gzip sudo
 

--- a/scripts/fetch_istio_releases.sh
+++ b/scripts/fetch_istio_releases.sh
@@ -6,7 +6,7 @@ RELEASE_DIR=${1}
 echo ${RELEASE_DIR}
 
 # Istio versions that need to be supported in the image for airgap installation.
-istio_version_array=(1.7.1 1.7.3 1.8.3 1.8.5 1.8.6 1.9.3 1.9.5 1.9.6 1.9.8 1.10.4 1.11.4 1.11.7)
+istio_version_array=(1.7.1 1.7.3 1.8.3 1.8.5 1.8.6 1.9.3 1.9.5 1.9.6 1.9.8 1.10.4 1.11.4 1.11.7 1.12.6)
 
 if [ -z "${RELEASE_DIR}" ]; then
   echo "No directory given"


### PR DESCRIPTION
Add istio 1.12.6 to the installer.

Linked issue:
https://github.com/rancher/rancher/issues/37218