### PR TITLE
[release/1.12] Remove MutatingWebhookConfiguration to fix istio reinstall issue.

### DIFF
--- a/scripts/uninstall_istio_system.sh
+++ b/scripts/uninstall_istio_system.sh
@@ -12,6 +12,10 @@ fi
 echo "uninstalling istio"
 istioctl manifest generate -i $ISTIO_NAMESPACE ${ISTIO_FILES[@]/#/-f } | kubectl delete --ignore-not-found=true -f -
 
+if kubectl get mutatingwebhookconfiguration istio-revision-tag-default -n istio-system; then
+  kubectl delete mutatingwebhookconfiguration  istio-revision-tag-default -n istio-system
+fi
+
 if kubectl get namespace cattle-dashboards; then
   kubectl delete configmap -n cattle-dashboards -l istio_dashboard=1
 fi


### PR DESCRIPTION
After uninstalling istio a MutatingWebhookConfiguration is left behind which causes reinstalling istio to error out. We need to cleanup this webhook in order to fix this error. This was validated and pointed out [here](https://github.com/rancher/rancher/issues/37218#issuecomment-1100244331).

This is a workaround untill upstream istio fixes this issue. https://github.com/istio/istio/issues/36905

Linked issue:
https://github.com/rancher/rancher/issues/37218
