### PR TITLE
[1.11] Remove old `validatingwebhookconfiguration` `istiod-istio-system` while uninstalling Istio

### DIFF
--- a/scripts/uninstall_istio_system.sh
+++ b/scripts/uninstall_istio_system.sh
@@ -12,6 +12,10 @@ fi
 echo "uninstalling istio"
 istioctl manifest generate -i $ISTIO_NAMESPACE ${ISTIO_FILES[@]/#/-f } | kubectl delete --ignore-not-found=true -f -
 
+if kubectl get validatingwebhookconfiguration istiod-istio-system; then
+  kubectl delete validatingwebhookconfiguration istiod-istio-system
+fi
+
 if kubectl get namespace cattle-dashboards; then
   kubectl delete configmap -n cattle-dashboards -l istio_dashboard=1
 fi


### PR DESCRIPTION
Related: https://github.com/rancher/rancher/issues/35742

This will remove the old `validatingwebhookconfiguration` `istiod-istio-system` while uninstalling Istio. This is a potential fix of the above mentioned issue. 