### PR TITLE
Add support for arm64 in 1.18

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,5 @@
 kind: pipeline
-name: linux-amd64
+name: image-linux-amd64
 platform:
   os: linux
   arch: amd64
@@ -18,7 +18,7 @@ steps:
   settings:
     dockerfile: Dockerfile
     repo: "rancher/istio-installer"
-    tag: "${DRONE_TAG}"
+    tag: "${DRONE_TAG}-amd64"
     username:
       from_secret: docker_username
     password:
@@ -31,3 +31,69 @@ steps:
     - refs/tags/*
     event:
     - tag
+
+---
+
+kind: pipeline
+name: image-linux-arm64
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: docker-build
+  image: plugins/docker
+  settings:
+    dockerfile: Dockerfile
+    repo: "rancher/istio-installer"
+    tag: "dev"
+    dry_run: true
+
+- name: docker-publish
+  image: plugins/docker
+  settings:
+    dockerfile: Dockerfile
+    repo: "rancher/istio-installer"
+    tag: "${DRONE_TAG}-arm64"
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+
+---
+
+kind: pipeline
+name: image-manifest
+steps:
+- name: docker-manifest
+  image: plugins/manifest
+  settings:
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    target: "rancher/istio-installer:${DRONE_TAG}"
+    template: "rancher/istio-installer:${DRONE_TAG}-ARCH"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+
+depends_on:
+- image-linux-amd64
+- image-linux-arm64


### PR DESCRIPTION
This changes the drone.io build, so that it creates an amd64 specific tag and an arm64 specific tag, after which it creates a manifest, which combines the two. 

The combined version will be published with the original tag conventions (so without the arch suffix)

Same pull request as earlier, but I was asked to create one as well for 1.18

See #67

Closes https://github.com/rancher/rancher/issues/43578