### PR TITLE
Update Dockerfile to support arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,7 @@ RUN zypper -n update && \
     zypper -n install curl jq openssl nginx tar gzip sudo
 
 # Get Istio
-ARG TARGETOS
-ARG TARGETARCH
-RUN curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VERSION} TARGET_ARCH=${TARGETARCH} TARGET_OS=${TARGETOS} sh -
+RUN curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VERSION} sh -
 RUN mv istio-${ISTIO_VERSION}/bin/istioctl /usr/bin && chmod +x /usr/bin/istioctl
 
 # Get kubectl

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,14 @@ RUN zypper -n update && \
     zypper -n install curl jq openssl nginx tar gzip sudo
 
 # Get Istio
-RUN curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VERSION} sh -
+ARG TARGETOS
+ARG TARGETARCH
+RUN curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VERSION} TARGET_ARCH=${TARGETARCH} TARGET_OS=${TARGETOS} sh -
 RUN mv istio-${ISTIO_VERSION}/bin/istioctl /usr/bin && chmod +x /usr/bin/istioctl
 
 # Get kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+ARG TARGETPLATFORM
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/${TARGETPLATFORM}/kubectl
 RUN mv ./kubectl /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 
 # Add scripts for Istio


### PR DESCRIPTION
Both istioctl and kubectl needed to be installed with their respective arch in mind

Fixes bug from comments in https://github.com/rancher/rancher/issues/43578

This is the same PR as #69, but for 1.19