### PR TITLE
Revert "Revert "Update Dockerfile to support arm64""

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VERSION} sh -
 RUN mv istio-${ISTIO_VERSION}/bin/istioctl /usr/bin && chmod +x /usr/bin/istioctl
 
 # Get kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+ARG TARGETPLATFORM
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/${TARGETPLATFORM}/kubectl
 RUN mv ./kubectl /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 
 # Add scripts for Istio


### PR DESCRIPTION
#69 was reverted in #71 after @rohitsakala posted this: https://github.com/rancher/istio-installer/pull/69#issuecomment-1826684524

> @CC007 I had to revert this PR since it failed due to kubectl error. I didn't debug it.

I build the docker image myself and [pushed it to docker hub](https://hub.docker.com/layers/ccoo7/istio-installer/1.18.2-cc007-arm64/images/sha256-51a7b7026eac9352a086f931490be75f5da5db366389b76898e6de37e69825c8?context=repo). 
After doing so and using that image in Rancher's Istio chart, I had no issues during the installation:

![afbeelding](https://github.com/rancher/istio-installer/assets/5381337/3c94f821-bf79-4d04-8753-8292ae5dbd9c)
![afbeelding](https://github.com/rancher/istio-installer/assets/5381337/e3e326d5-a96d-4528-8343-06d2a730ca8b)

So I believe that the issue that was experienced was a false negative. This might have been caused by reusing the same tag name (1.18.2-rancher1), therefore I suggest to update the tag this time, even if that means that the chart itself will get a new release if necessary

If the issue can be reproduced, I'd gladly help fix the issue.

I'll wait with the 1.19 PR this time, until I know for sure that the 1.18 release works.