### PR TITLE
Fix tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,9 @@ jobs:
 
       - name: Build and push
         uses: docker/build-push-action@v5
+        env: 
+          IMAGE_TAG: ${{ inputs.imageTag || 'rancher/istio-installer' }}
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ inputs.imageTag }}:${{ github.ref_name }}
+          tags: ${{ env.IMAGE_TAG }}:${{ github.ref_name }}


### PR DESCRIPTION
I made a mistake: I thought that `on.workflow_dispatch.inputs.imageTag.default` would be used to set the value of `inputs.imageTag` when the workflow is triggered by a tag push. This is not the case: it is set to `''`. The solution is to hard-code this value to `rancher/istio-installer` when the workflow is triggered by a tag push.