### PR TITLE
Add support for arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VERSION} sh -
 RUN mv istio-${ISTIO_VERSION}/bin/istioctl /usr/bin && chmod +x /usr/bin/istioctl
 
 # Get kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+ARG TARGETPLATFORM
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/${TARGETPLATFORM}/kubectl
 RUN mv ./kubectl /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 
 # Add scripts for Istio


### PR DESCRIPTION
I see that the `.drone.yaml` was removed in favor of a github workflow `release.yaml` between 1.20 and 1.21. I do see that it still does release the arm chart with the new release pipeline, so this should still work.